### PR TITLE
Issue #22 mnemonic incorrectly listed as unkown

### DIFF
--- a/mar/ace/mode-mar.js
+++ b/mar/ace/mode-mar.js
@@ -47,12 +47,12 @@ define("ace/mode/mar_rules", ["require", "exports", "module", "ace/lib/oop", "ac
             start:
                 [{
                     token: 'keyword.function.assembly',
-                    regex: '\\b(?:mov|add|sub|and|or|test|cmp|shl|shr|mul|push|pop|div|xor|dw|nop|equ|neg|hwq|not|ror|rol|sal|sar)\\b',
+                    regex: '\\b(?:mov|add|sub|and|or|test|cmp|shl|shr|mul|push|pop|div|xor|dw|nop|equ|neg|hwq|not|ror|rol|sal|sar|rcl|rcr|xchg)\\b',
                     caseInsensitive: true
                 },
                     {
                         token: 'keyword.operator.assembly',
-                        regex: '\\b(?:call|ret|jmp|jnz|jg|jl|jge|jle|hwi|jz|js|jns|jc|jnc)\\b',
+                        regex: '\\b(?:call|ret|jmp|jnz|jg|jl|jge|jle|hwi|jz|js|jns|jc|jnc|jo|jno)\\b',
                         caseInsensitive: true
                     },
                     {

--- a/mar/editor.js
+++ b/mar/editor.js
@@ -20,7 +20,8 @@ var MarParserSyntax = {
         'bp', 'sp'
     ],
     doubleOperandInstructions : [
-        'mov', 'add', 'sub', 'and', 'or', 'test', 'cmp', 'shl', 'shr', 'xor', 'rol', 'ror', 'sal', 'sar'
+        'mov', 'add', 'sub', 'and', 'or', 'test', 'cmp', 'shl', 'shr', 'xor', 'rol', 'ror', 'sal', 'sar',
+        'xchg', 'rcl', 'rcr'
     ],
     singleOperandInstructions : [
         'push', 'mul', 'pop', 'div', 'neg', 'call', 'jnz', 'jg', 'jl', 'jge', 'jle', 'hwi', 'hwq', 'jz',


### PR DESCRIPTION
So this PR fixes both the missing operands for the client side linter/parser and the missing syntax highlighting for added instructions and missing instructions.

Might be useful to also implement some kind `MarParserSyntax` like object to the `ace/mode-mar.js` file. I'd prefer this over editing the `RegExp` directly. Though my naming is a bit verbose.