### PR TITLE
hide editor for guests.

### DIFF
--- a/game.php
+++ b/game.php
@@ -127,11 +127,17 @@ if (isset($user)) {
                         <ul>
                             <li><a class="button alt" href="#game" onclick="gameClick()">Game</a>
                             </li>
+                            <?php if($user) { ?>
                             <li><a class="button alt" href="#editorTab" onclick="editorClick()">Editor</a>
                             </li>
+                            <?php } else { ?>
+                            <li><a class="button alt" onclick="window.location = '/login.php';">Editor</a>
+                            </li>
+                            <?php } ?>
                         </ul>
 
                         <!-- Editor buttons -->
+                        <?php if($user) { ?>
                         <div id="editorBtns" style="display: none">
                             <a class="button editorBtn" onclick="mar.client.uploadCode(ace.edit('editor').getValue())">Upload</a>
                             <a class="button editorBtn" onclick="mar.client.reloadCode()">Reload</a>
@@ -146,6 +152,7 @@ if (isset($user)) {
                             <!-- Style the select to something more select'y -->
                             <select title="Select Theme" class="button editorBtn" id="editorTheme"></select>
                         </div>
+                        <?php } ?>
 
                         <div id="gameBtns">
                             <a class="button editorBtn" onclick="findMyRobot()">Find My Robot</a>


### PR DESCRIPTION
This PR hides the editor for not logged in users. Instead it redirects a click on the editor button to the login page.

> NOTE: i had to use `onclick='window.location = "/login.php"' because it is inside the #tabs div which does not redirect the page but instead loads the page to its inner contents`

fixes #18